### PR TITLE
DEV-ONLY: Use the veracode CLI full path

### DIFF
--- a/.github/workflows/static-scan-veracode.yml
+++ b/.github/workflows/static-scan-veracode.yml
@@ -56,7 +56,7 @@ jobs:
           mkdir -p veracode-artifacts
 
           # Use Veracode CLI to auto-package the project
-          veracode package \
+          /home/runner/work/DotRush/DotRush/veracode package \
             --source . \
             --output ./veracode-artifacts \
             --trust \


### PR DESCRIPTION
Couldn't find the veracode cli when using the `package` subcommand
